### PR TITLE
change sourceType to module

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -268,3 +268,4 @@ globals:
   clearInterval: readonly
 parserOptions:
   ecmaVersion: 2022
+  sourceType: module


### PR DESCRIPTION
This allows eslint to fix gnome-45 modules and won't stop fixing of older files.